### PR TITLE
Fix bare struct and union references for CFFI

### DIFF
--- a/ip-interfaces.lisp
+++ b/ip-interfaces.lisp
@@ -30,7 +30,6 @@
   address-family)
 
 (defun bytes (pointer count)
-  (declare (optimize (debug 3)))
   (apply #'vector (loop for i from 0 below count
                      collect (mem-aref pointer :uchar i))))
 
@@ -68,7 +67,6 @@
 
 #+windows
 (defun get-ip-interfaces ()
-  (declare (optimize (debug 3)))
   (with-foreign-object (wsadata '(:struct wsadata))
     (unless (zerop (wsastartup #x0202 wsadata))
       (return-from get-ip-interfaces)))

--- a/ip-interfaces.lisp
+++ b/ip-interfaces.lisp
@@ -30,6 +30,7 @@
   address-family)
 
 (defun bytes (pointer count)
+  (declare (optimize (debug 3)))
   (apply #'vector (loop for i from 0 below count
                      collect (mem-aref pointer :uchar i))))
 
@@ -67,6 +68,7 @@
 
 #+windows
 (defun get-ip-interfaces ()
+  (declare (optimize (debug 3)))
   (with-foreign-object (wsadata '(:struct wsadata))
     (unless (zerop (wsastartup #x0202 wsadata))
       (return-from get-ip-interfaces)))
@@ -100,9 +102,9 @@
 		       (push (make-ip-interface
 			      :name (format nil "ip~d" nameidx)
 			      :address
-			      (bytes (foreign-slot-value
-				      (foreign-slot-value
-				       (foreign-slot-value
+			      (bytes (foreign-slot-pointer
+				      (foreign-slot-pointer
+				       (foreign-slot-pointer
 					p '(:struct interface-info) 'ii-address)
 				       '(:union sockaddr-gen)
 				       'address-in)
@@ -110,9 +112,9 @@
 				      'sin-addr)
 				     4)
 			      :netmask
-			      (bytes (foreign-slot-value
-				      (foreign-slot-value
-				       (foreign-slot-value
+			      (bytes (foreign-slot-pointer
+				      (foreign-slot-pointer
+				       (foreign-slot-pointer
 					p '(:struct interface-info) 'ii-netmask)
 				       '(:union sockaddr-gen)
 				       'address-in)
@@ -120,9 +122,9 @@
 				      'sin-addr)
 				     4)
 			      :broadcast-address
-			      (bytes (foreign-slot-value
-				      (foreign-slot-value
-				       (foreign-slot-value
+			      (bytes (foreign-slot-pointer
+				      (foreign-slot-pointer
+				       (foreign-slot-pointer
 					p '(:struct interface-info)
 					'ii-broadcast-address)
 				       '(:union sockaddr-gen)

--- a/ip-interfaces.lisp
+++ b/ip-interfaces.lisp
@@ -67,15 +67,15 @@
 
 #+windows
 (defun get-ip-interfaces ()
-  (with-foreign-object (wsadata 'wsadata)
+  (with-foreign-object (wsadata '(:struct wsadata))
     (unless (zerop (wsastartup #x0202 wsadata))
       (return-from get-ip-interfaces)))
   (let ((socket (socket :af-inet :sock-dgram :ipproto-ip)))
     (unwind-protect
     (with-foreign-object (realoutlen 'dword)
       (do* ((i 128 (* i 2))
-	    (reservedlen (* i (foreign-type-size 'interface-info))
-			 (* i (foreign-type-size 'interface-info))))
+	    (reservedlen (* i (foreign-type-size '(:struct interface-info)))
+			 (* i (foreign-type-size '(:struct interface-info)))))
 	   ((> i 1024))
 	(with-foreign-object (buf :uchar reservedlen)
 	  (unless (zerop (wsaioctl
@@ -93,7 +93,7 @@
 	    (when (< noutbytes reservedlen)
 	      (let ((interfaces nil))
 		(do* ((offset 0 (+ offset
-				   (foreign-type-size 'interface-info)))
+				   (foreign-type-size '(:struct interface-info))))
 		      (nameidx 0 (1+ nameidx)))
 		     ((>= offset noutbytes))
 		     (let ((p (inc-pointer buf offset)))
@@ -103,35 +103,35 @@
 			      (bytes (foreign-slot-value
 				      (foreign-slot-value
 				       (foreign-slot-value
-					p 'interface-info 'ii-address)
-				       'sockaddr-gen
+					p '(:struct interface-info) 'ii-address)
+				       '(:union sockaddr-gen)
 				       'address-in)
-				      'sockaddr-in
+				      '(:struct sockaddr-in)
 				      'sin-addr)
 				     4)
 			      :netmask
 			      (bytes (foreign-slot-value
 				      (foreign-slot-value
 				       (foreign-slot-value
-					p 'interface-info 'ii-netmask)
-				       'sockaddr-gen
+					p '(:struct interface-info) 'ii-netmask)
+				       '(:union sockaddr-gen)
 				       'address-in)
-				      'sockaddr-in
+				      '(:struct sockaddr-in)
 				      'sin-addr)
 				     4)
 			      :broadcast-address
 			      (bytes (foreign-slot-value
 				      (foreign-slot-value
 				       (foreign-slot-value
-					p 'interface-info
+					p '(:struct interface-info)
 					'ii-broadcast-address)
-				       'sockaddr-gen
+				       '(:union sockaddr-gen)
 				       'address-in)
-				      'sockaddr-in
+				      '(:struct sockaddr-in)
 				      'sin-addr)
 				     4)
 			      :flags (foreign-slot-value
-				      p 'interface-info 'ii-flags)
+				      p '(:struct interface-info) 'ii-flags)
 			      :address-family :af-inet)
 			     interfaces)))
 		(return interfaces)))))))

--- a/sockets.lisp
+++ b/sockets.lisp
@@ -42,10 +42,10 @@
     (ifa-data :pointer))
 
   (defcfun "getifaddrs" :int
-    (ifaddrs (:pointer (:pointer ifaddrs))))
+    (ifaddrs (:pointer (:pointer (:struct ifaddrs)))))
 
   (defcfun "freeifaddrs" :void
-    (ifaddrs (:pointer ifaddrs))))
+    (ifaddrs (:pointer (:struct ifaddrs)))))
 
 #+windows
 (progn
@@ -77,15 +77,15 @@
     (sin6-addr :uchar :count 16))
 
   (defcunion sockaddr-gen
-    (address sockaddr)
-    (address-in sockaddr-in)
-    (address-in6 sockaddr-in6-old))
+    (address (:struct sockaddr))
+    (address-in (:struct sockaddr-in))
+    (address-in6 (:struct sockaddr-in6-old)))
 
   (defcstruct interface-info
     (ii-flags :ulong)
-    (ii-address sockaddr-gen)
-    (ii-broadcast-address sockaddr-gen)
-    (ii-netmask sockaddr-gen))
+    (ii-address (:union sockaddr-gen))
+    (ii-broadcast-address (:union sockaddr-gen))
+    (ii-netmask (:union sockaddr-gen)))
 
   (defcstruct wsadata
     (w-version word)
@@ -106,7 +106,7 @@
 
   (defcfun "WSAStartup" :int
     (w-version-requested word)
-    (lp-wsadata (:pointer wsadata)))
+    (lp-wsadata (:pointer (:struct wsadata))))
 
   (defcfun "WSAIoctl" :int
     (socket socket)


### PR DESCRIPTION
This fixes warnings at compile-time by CFFI, and warnings at runtime on Windows.